### PR TITLE
fix: get rid of single line object literals

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -629,35 +629,26 @@ const ObjectExpression = ({
     filter(([, value]) => value != null),
     reduce(toMap()),
   )
-  switch (filteredProperties.size) {
-    case 0:
-      return emitEmpty ? `{}` : ``
-    case 1: {
-      const [name, value] = get(first(filteredProperties))
-      return code`{ ${ts.ObjectProperty({
-        name,
-        // https://github.com/alloy-framework/alloy/issues/42
-        value: typeof value === `number` ? String(value) : value,
-      })} }`
-    }
-    default:
-      return ts.ObjectExpression().children(
-        ayJoin(
-          pipe(
-            filteredProperties,
-            map(
-              ([name, value]) =>
-                code`${ts.ObjectProperty({
-                  name,
-                  // https://github.com/alloy-framework/alloy/issues/42
-                  value: typeof value === `number` ? String(value) : value,
-                })},\n`,
-            ),
-            reduce(toArray()),
-          ),
-        ),
-      )
+  if (filteredProperties.size === 0) {
+    return emitEmpty ? `{}` : ``
   }
+
+  return ts.ObjectExpression().children(
+    ayJoin(
+      pipe(
+        filteredProperties,
+        map(
+          ([name, value]) =>
+            code`${ts.ObjectProperty({
+              name,
+              // https://github.com/alloy-framework/alloy/issues/42
+              value: typeof value === `number` ? String(value) : value,
+            })},\n`,
+        ),
+        reduce(toArray()),
+      ),
+    ),
+  )
 }
 
 const RecursiveReferenceArbitrary = ({

--- a/test/snapshots/array/arbitraries.js
+++ b/test/snapshots/array/arbitraries.js
@@ -2,15 +2,21 @@ import * as fc from 'fast-check';
 
 export const $Array = fc.array(fc.string());
 
-export const MinItemsArray = fc.array(fc.string(), { minLength: 3 });
+export const MinItemsArray = fc.array(fc.string(), {
+  minLength: 3,
+});
 
 export const Min0ItemsArray = fc.array(fc.string());
 
-export const MaxItemsArray = fc.array(fc.string(), { maxLength: 12 });
+export const MaxItemsArray = fc.array(fc.string(), {
+  maxLength: 12,
+});
 
 export const MinMaxItemsArray = fc.array(fc.string(), {
   minLength: 3,
   maxLength: 12,
 });
 
-export const $Model = fc.record({ property: fc.array(fc.string()) });
+export const $Model = fc.record({
+  property: fc.array(fc.string()),
+});

--- a/test/snapshots/comments/arbitraries.js
+++ b/test/snapshots/comments/arbitraries.js
@@ -1,19 +1,31 @@
 import * as fc from 'fast-check';
 
-const group = fc.letrec(tie => ({ MultiLineRecursiveModel: fc.record(
-  { property: tie('MultiLineRecursiveModel') },
-  { withDeletedKeys: true },
-) }));
+const group = fc.letrec(tie => ({
+  MultiLineRecursiveModel: fc.record(
+    {
+      property: tie('MultiLineRecursiveModel'),
+    },
+    {
+      withDeletedKeys: true,
+    },
+  ),
+}));
 /**
  * Recursive
  * model comment.
  */
 export const MultiLineRecursiveModel = group.MultiLineRecursiveModel;
 
-const group_2 = fc.letrec(tie => ({ SingleLineRecursiveModel: fc.record(
-  { property: tie('SingleLineRecursiveModel') },
-  { withDeletedKeys: true },
-) }));
+const group_2 = fc.letrec(tie => ({
+  SingleLineRecursiveModel: fc.record(
+    {
+      property: tie('SingleLineRecursiveModel'),
+    },
+    {
+      withDeletedKeys: true,
+    },
+  ),
+}));
 /** Recursive model comment. */
 export const SingleLineRecursiveModel = group_2.SingleLineRecursiveModel;
 
@@ -54,10 +66,14 @@ export const MultiLineNamespace = {
 };
 
 /** Non-shared model comment. */
-export const SingleLineNonSharedModel = fc.record({ property: SingleLineSharedModel });
+export const SingleLineNonSharedModel = fc.record({
+  property: SingleLineSharedModel,
+});
 
 /**
  * Non-shared
  * model comment.
  */
-export const MultiLineNonSharedModel = fc.record({ property: MultiLineSharedModel });
+export const MultiLineNonSharedModel = fc.record({
+  property: MultiLineSharedModel,
+});

--- a/test/snapshots/decimal/arbitraries.js
+++ b/test/snapshots/decimal/arbitraries.js
@@ -2,9 +2,13 @@ import * as fc from 'fast-check';
 
 export const Decimal = fc.double();
 
-export const MinValueDecimal = fc.double({ min: -3.4e+39 });
+export const MinValueDecimal = fc.double({
+  min: -3.4e+39,
+});
 
-export const MaxValueDecimal = fc.double({ max: 3.4e+39 });
+export const MaxValueDecimal = fc.double({
+  max: 3.4e+39,
+});
 
 export const MinMaxValueDecimal = fc.double({
   min: -3.4e+39,

--- a/test/snapshots/decimal128/arbitraries.js
+++ b/test/snapshots/decimal128/arbitraries.js
@@ -2,9 +2,13 @@ import * as fc from 'fast-check';
 
 export const Decimal128 = fc.double();
 
-export const MinValueDecimal128 = fc.double({ min: -3.4e+39 });
+export const MinValueDecimal128 = fc.double({
+  min: -3.4e+39,
+});
 
-export const MaxValueDecimal128 = fc.double({ max: 3.4e+39 });
+export const MaxValueDecimal128 = fc.double({
+  max: 3.4e+39,
+});
 
 export const MinMaxValueDecimal128 = fc.double({
   min: -3.4e+39,

--- a/test/snapshots/float32/arbitraries.js
+++ b/test/snapshots/float32/arbitraries.js
@@ -2,11 +2,17 @@ import * as fc from 'fast-check';
 
 export const Float32 = fc.float();
 
-export const MinValueFloat32 = fc.float({ min: -3.140000104904175 });
+export const MinValueFloat32 = fc.float({
+  min: -3.140000104904175,
+});
 
-export const MinValue0Float32 = fc.float({ min: 0 });
+export const MinValue0Float32 = fc.float({
+  min: 0,
+});
 
-export const MaxValueFloat32 = fc.float({ max: 3.140000104904175 });
+export const MaxValueFloat32 = fc.float({
+  max: 3.140000104904175,
+});
 
 export const MinMaxValueFloat32 = fc.float({
   min: -3.140000104904175,

--- a/test/snapshots/float64/arbitraries.js
+++ b/test/snapshots/float64/arbitraries.js
@@ -2,9 +2,13 @@ import * as fc from 'fast-check';
 
 export const Float64 = fc.double();
 
-export const MinValueFloat64 = fc.double({ min: -3.4e+39 });
+export const MinValueFloat64 = fc.double({
+  min: -3.4e+39,
+});
 
-export const MaxValueFloat64 = fc.double({ max: 3.4e+39 });
+export const MaxValueFloat64 = fc.double({
+  max: 3.4e+39,
+});
 
 export const MinMaxValueFloat64 = fc.double({
   min: -3.4e+39,

--- a/test/snapshots/int16/arbitraries.js
+++ b/test/snapshots/int16/arbitraries.js
@@ -12,7 +12,9 @@ export const MinValueInt16 = fc.integer({
   max: 32767,
 });
 
-export const Min0ValueInt16 = fc.nat({ max: 32767 });
+export const Min0ValueInt16 = fc.nat({
+  max: 32767,
+});
 
 export const MaxValueInt16 = fc.integer({
   min: -32768,

--- a/test/snapshots/int32/arbitraries.js
+++ b/test/snapshots/int32/arbitraries.js
@@ -2,11 +2,15 @@ import * as fc from 'fast-check';
 
 export const Int32 = fc.integer();
 
-export const MinValueInt32 = fc.integer({ min: -40000 });
+export const MinValueInt32 = fc.integer({
+  min: -40000,
+});
 
 export const Min0ValueInt32 = fc.nat();
 
-export const MaxValueInt32 = fc.integer({ max: 40000 });
+export const MaxValueInt32 = fc.integer({
+  max: 40000,
+});
 
 export const MinMaxValueInt32 = fc.integer({
   min: -40000,

--- a/test/snapshots/int8/arbitraries.js
+++ b/test/snapshots/int8/arbitraries.js
@@ -12,7 +12,9 @@ export const MinValueInt8 = fc.integer({
   max: 127,
 });
 
-export const Min0ValueInt8 = fc.nat({ max: 127 });
+export const Min0ValueInt8 = fc.nat({
+  max: 127,
+});
 
 export const MaxValueInt8 = fc.integer({
   min: -128,

--- a/test/snapshots/integer/arbitraries.js
+++ b/test/snapshots/integer/arbitraries.js
@@ -2,11 +2,17 @@ import * as fc from 'fast-check';
 
 export const Integer = fc.bigInt();
 
-export const MinValueInteger = fc.bigInt({ min: 92233720368547758000n });
+export const MinValueInteger = fc.bigInt({
+  min: 92233720368547758000n,
+});
 
-export const MinValue0Integer = fc.bigInt({ min: 0n });
+export const MinValue0Integer = fc.bigInt({
+  min: 0n,
+});
 
-export const MaxValueInteger = fc.bigInt({ max: 922337203685477580000n });
+export const MaxValueInteger = fc.bigInt({
+  max: 922337203685477580000n,
+});
 
 export const MinMaxValueInteger = fc.bigInt({
   min: 92233720368547758000n,

--- a/test/snapshots/model-default-property/arbitraries.js
+++ b/test/snapshots/model-default-property/arbitraries.js
@@ -93,5 +93,7 @@ export const DefaultPropertiesModel = fc.record(
       }),
     ),
   },
-  { withDeletedKeys: true },
+  {
+    withDeletedKeys: true,
+  },
 );

--- a/test/snapshots/model-intersection/arbitraries.js
+++ b/test/snapshots/model-intersection/arbitraries.js
@@ -1,12 +1,18 @@
 import * as fc from 'fast-check';
 
-export const Model1 = fc.record({ a: fc.integer() });
+export const Model1 = fc.record({
+  a: fc.integer(),
+});
 
-export const Model2 = fc.record({ b: fc.string() });
+export const Model2 = fc.record({
+  b: fc.string(),
+});
 
-export const $Model = fc.record({ property: fc
-  .tuple(
-    Model1,
-    Model2,
-  )
-  .map(values => Object.assign(...values)) });
+export const $Model = fc.record({
+  property: fc
+    .tuple(
+      Model1,
+      Model2,
+    )
+    .map(values => Object.assign(...values)),
+});

--- a/test/snapshots/model-is/arbitraries.js
+++ b/test/snapshots/model-is/arbitraries.js
@@ -1,12 +1,16 @@
 import * as fc from 'fast-check';
 
-export const Model1 = fc.record({ a: fc.integer() });
+export const Model1 = fc.record({
+  a: fc.integer(),
+});
 
 export const Model2 = Model1;
 
 export const Model3 = fc
   .tuple(
     Model1,
-    fc.record({ b: fc.string() }),
+    fc.record({
+      b: fc.string(),
+    }),
   )
   .map(values => Object.assign(...values));

--- a/test/snapshots/model-optional-property/arbitraries.js
+++ b/test/snapshots/model-optional-property/arbitraries.js
@@ -19,7 +19,9 @@ export const AllOptionalModel = fc.record(
     b: fc.string(),
     c: int64,
   },
-  { withDeletedKeys: true },
+  {
+    withDeletedKeys: true,
+  },
 );
 
 export const SomeOptionalModel = fc.record(
@@ -28,5 +30,7 @@ export const SomeOptionalModel = fc.record(
     b: fc.string(),
     c: int64,
   },
-  { requiredKeys: ['b'] },
+  {
+    requiredKeys: ['b'],
+  },
 );

--- a/test/snapshots/model-property-reference/arbitraries.js
+++ b/test/snapshots/model-property-reference/arbitraries.js
@@ -1,5 +1,9 @@
 import * as fc from 'fast-check';
 
-export const Model1 = fc.record({ property: fc.string() });
+export const Model1 = fc.record({
+  property: fc.string(),
+});
 
-export const Model2 = fc.record({ property: fc.string() });
+export const Model2 = fc.record({
+  property: fc.string(),
+});

--- a/test/snapshots/model-spread/arbitraries.js
+++ b/test/snapshots/model-spread/arbitraries.js
@@ -1,14 +1,20 @@
 import * as fc from 'fast-check';
 
-export const Model1 = fc.record({ a: fc.integer() });
+export const Model1 = fc.record({
+  a: fc.integer(),
+});
 
-export const Model2 = fc.record({ b: fc.string() });
+export const Model2 = fc.record({
+  b: fc.string(),
+});
 
 export const $Model = fc
   .tuple(
     Model1,
     Model2,
     fc.dictionary(fc.string(), fc.boolean()),
-    fc.record({ c: fc.string() }),
+    fc.record({
+      c: fc.string(),
+    }),
   )
   .map(values => Object.assign(...values));

--- a/test/snapshots/mutually-recursive-models/arbitraries.js
+++ b/test/snapshots/mutually-recursive-models/arbitraries.js
@@ -6,14 +6,18 @@ const group = fc.letrec(tie => ({
       value: fc.string(),
       next: tie('BooleanNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
   BooleanNode: fc.record(
     {
       value: fc.boolean(),
       next: tie('StringNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
 }));
 export const StringNode = group.StringNode;

--- a/test/snapshots/nested-namespace-mutually-recursive-models/arbitraries.js
+++ b/test/snapshots/nested-namespace-mutually-recursive-models/arbitraries.js
@@ -6,14 +6,18 @@ const group = fc.letrec(tie => ({
       value: fc.string(),
       next: tie('BooleanNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
   BooleanNode: fc.record(
     {
       value: fc.boolean(),
       next: tie('StringNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
 }));
 const StringNode = group.StringNode;

--- a/test/snapshots/nested-namespace-recursive-model/arbitraries.js
+++ b/test/snapshots/nested-namespace-recursive-model/arbitraries.js
@@ -1,12 +1,16 @@
 import * as fc from 'fast-check';
 
-const group = fc.letrec(tie => ({ Node: fc.record(
-  {
-    value: fc.string(),
-    next: tie('Node'),
-  },
-  { requiredKeys: ['value'] },
-) }));
+const group = fc.letrec(tie => ({
+  Node: fc.record(
+    {
+      value: fc.string(),
+      next: tie('Node'),
+    },
+    {
+      requiredKeys: ['value'],
+    },
+  ),
+}));
 const Node = group.Node;
 
 export const $Namespace = {

--- a/test/snapshots/never/arbitraries.js
+++ b/test/snapshots/never/arbitraries.js
@@ -1,5 +1,7 @@
 import * as fc from 'fast-check';
 
-export const $Model = fc.record({ property: fc.constant(null).map(() => {
-  throw new Error('never');
-}) });
+export const $Model = fc.record({
+  property: fc.constant(null).map(() => {
+    throw new Error('never');
+  }),
+});

--- a/test/snapshots/null/arbitraries.js
+++ b/test/snapshots/null/arbitraries.js
@@ -1,3 +1,5 @@
 import * as fc from 'fast-check';
 
-export const $Model = fc.record({ property: fc.constant(null) });
+export const $Model = fc.record({
+  property: fc.constant(null),
+});

--- a/test/snapshots/numeric-sharing/arbitraries.js
+++ b/test/snapshots/numeric-sharing/arbitraries.js
@@ -37,7 +37,9 @@ export const FirstInt32 = fc.integer();
 
 export const SecondInt32 = fc.integer();
 
-export const ThirdInt32 = fc.integer({ min: 42 });
+export const ThirdInt32 = fc.integer({
+  min: 42,
+});
 
 export const FirstSafeInt = fc.maxSafeInteger();
 
@@ -61,34 +63,46 @@ export const FirstInteger = fc.bigInt();
 
 export const SecondInteger = fc.bigInt();
 
-export const ThirdInteger = fc.bigInt({ min: 42n });
+export const ThirdInteger = fc.bigInt({
+  min: 42n,
+});
 
 export const FirstFloat32 = fc.float();
 
 export const SecondFloat32 = fc.float();
 
-export const ThirdFloat32 = fc.float({ min: 42 });
+export const ThirdFloat32 = fc.float({
+  min: 42,
+});
 
 export const FirstFloat64 = fc.double();
 
 export const SecondFloat64 = fc.double();
 
-export const ThirdFloat64 = fc.double({ min: 42 });
+export const ThirdFloat64 = fc.double({
+  min: 42,
+});
 
 export const FirstDecimal128 = fc.double();
 
 export const SecondDecimal128 = fc.double();
 
-export const ThirdDecimal128 = fc.double({ min: 42 });
+export const ThirdDecimal128 = fc.double({
+  min: 42,
+});
 
 export const FirstDecimal = fc.double();
 
 export const SecondDecimal = fc.double();
 
-export const ThirdDecimal = fc.double({ min: 42 });
+export const ThirdDecimal = fc.double({
+  min: 42,
+});
 
 export const FirstNumeric = fc.double();
 
 export const SecondNumeric = fc.double();
 
-export const ThirdNumeric = fc.double({ min: 42 });
+export const ThirdNumeric = fc.double({
+  min: 42,
+});

--- a/test/snapshots/numeric/arbitraries.js
+++ b/test/snapshots/numeric/arbitraries.js
@@ -8,9 +8,13 @@ export const $Model = fc.record({
 
 export const Numeric = fc.double();
 
-export const MinValueNumeric = fc.double({ min: -3.4e+39 });
+export const MinValueNumeric = fc.double({
+  min: -3.4e+39,
+});
 
-export const MaxValueNumeric = fc.double({ max: 3.4e+39 });
+export const MaxValueNumeric = fc.double({
+  max: 3.4e+39,
+});
 
 export const MinMaxValueNumeric = fc.double({
   min: -3.4e+39,

--- a/test/snapshots/recursive-model/arbitraries.js
+++ b/test/snapshots/recursive-model/arbitraries.js
@@ -1,10 +1,14 @@
 import * as fc from 'fast-check';
 
-const group = fc.letrec(tie => ({ Node: fc.record(
-  {
-    value: fc.string(),
-    next: tie('Node'),
-  },
-  { requiredKeys: ['value'] },
-) }));
+const group = fc.letrec(tie => ({
+  Node: fc.record(
+    {
+      value: fc.string(),
+      next: tie('Node'),
+    },
+    {
+      requiredKeys: ['value'],
+    },
+  ),
+}));
 export const Node = group.Node;

--- a/test/snapshots/recursive-models-topological-sort/arbitraries.js
+++ b/test/snapshots/recursive-models-topological-sort/arbitraries.js
@@ -6,28 +6,36 @@ const group = fc.letrec(tie => ({
       value: fc.string(),
       next: tie('BooleanNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
   BooleanNode: fc.record(
     {
       value: fc.boolean(),
       next: tie('StringNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
 }));
 export const StringNode = group.StringNode;
 export const BooleanNode = group.BooleanNode;
 
-const group_2 = fc.letrec(tie => ({ Tree: fc.record(
-  {
-    value: fc.integer(),
-    left: tie('Tree'),
-    right: fc.oneof(
-      tie('Tree'),
-      StringNode,
-    ),
-  },
-  { requiredKeys: ['value'] },
-) }));
+const group_2 = fc.letrec(tie => ({
+  Tree: fc.record(
+    {
+      value: fc.integer(),
+      left: tie('Tree'),
+      right: fc.oneof(
+        tie('Tree'),
+        StringNode,
+      ),
+    },
+    {
+      requiredKeys: ['value'],
+    },
+  ),
+}));
 export const Tree = group_2.Tree;

--- a/test/snapshots/string/arbitraries.js
+++ b/test/snapshots/string/arbitraries.js
@@ -7,9 +7,13 @@ export const $Model = fc.record({
 
 export const String = fc.string();
 
-export const MinLengthString = fc.string({ minLength: 1 });
+export const MinLengthString = fc.string({
+  minLength: 1,
+});
 
-export const MaxLengthString = fc.string({ maxLength: 5 });
+export const MaxLengthString = fc.string({
+  maxLength: 5,
+});
 
 export const MinAndMaxLengthString = fc.string({
   minLength: 2,

--- a/test/snapshots/super-mutually-recursive-models/arbitraries.js
+++ b/test/snapshots/super-mutually-recursive-models/arbitraries.js
@@ -10,14 +10,18 @@ const group = fc.letrec(tie => ({
         tie('Tree'),
       ),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
   StringNode: fc.record(
     {
       value: fc.string(),
       next: tie('BooleanNode'),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
   BooleanNode: fc.record(
     {
@@ -27,7 +31,9 @@ const group = fc.letrec(tie => ({
         tie('Tree'),
       ),
     },
-    { requiredKeys: ['value'] },
+    {
+      requiredKeys: ['value'],
+    },
   ),
 }));
 export const Tree = group.Tree;

--- a/test/snapshots/unknown/arbitraries.js
+++ b/test/snapshots/unknown/arbitraries.js
@@ -1,3 +1,5 @@
 import * as fc from 'fast-check';
 
-export const $Model = fc.record({ property: fc.anything() });
+export const $Model = fc.record({
+  property: fc.anything(),
+});

--- a/test/snapshots/void/arbitraries.js
+++ b/test/snapshots/void/arbitraries.js
@@ -1,3 +1,5 @@
 import * as fc from 'fast-check';
 
-export const $Model = fc.record({ property: fc.constant(undefined) });
+export const $Model = fc.record({
+  property: fc.constant(undefined),
+});


### PR DESCRIPTION
Causes weird formatting for objects with one property that has a multiline value.